### PR TITLE
fix(anthropic): respect stream:false and return JSON Message body

### DIFF
--- a/plugins/anthropic/handlers.go
+++ b/plugins/anthropic/handlers.go
@@ -1,5 +1,5 @@
-// ABOUTME: HTTP handler for POST /v1/messages with SSE streaming
-// ABOUTME: Matches user messages against scenarios and streams Anthropic-format responses
+// ABOUTME: HTTP handler for POST /v1/messages with SSE streaming and JSON non-streaming transports
+// ABOUTME: Matches user messages against scenarios and returns Anthropic-format responses
 
 package anthropic
 
@@ -26,7 +26,9 @@ type messageContent struct {
 	Content json.RawMessage `json:"content"`
 }
 
-// handleMessages handles POST /v1/messages and streams SSE responses.
+// handleMessages handles POST /v1/messages. It returns SSE events when
+// req.Stream is true and a single JSON Message body otherwise (matching real
+// Anthropic, where stream defaults to false).
 func (p *AnthropicPlugin) handleMessages(w http.ResponseWriter, r *http.Request) {
 	if p.store == nil {
 		writeError(w, http.StatusInternalServerError, "Plugin not initialized")
@@ -60,7 +62,11 @@ func (p *AnthropicPlugin) handleMessages(w http.ResponseWriter, r *http.Request)
 	if containsToolResult(lastMsg) {
 		toolContent := extractToolResultContent(lastMsg)
 		responseText := "Based on the tool result: " + toolContent
-		p.streamTextResponse(w, req.Model, responseText, string(bodyBytes), "")
+		if req.Stream {
+			p.streamTextResponse(w, req.Model, responseText, string(bodyBytes), "")
+		} else {
+			p.respondTextNonStream(w, req.Model, responseText, string(bodyBytes), "")
+		}
 		return
 	}
 
@@ -72,7 +78,11 @@ func (p *AnthropicPlugin) handleMessages(w http.ResponseWriter, r *http.Request)
 		if err == sql.ErrNoRows {
 			// No scenarios match; use hardcoded fallback
 			fallbackText := "I understand your request. How can I help you?"
-			p.streamTextResponse(w, req.Model, fallbackText, string(bodyBytes), "")
+			if req.Stream {
+				p.streamTextResponse(w, req.Model, fallbackText, string(bodyBytes), "")
+			} else {
+				p.respondTextNonStream(w, req.Model, fallbackText, string(bodyBytes), "")
+			}
 			return
 		}
 		writeError(w, http.StatusInternalServerError, "Failed to match scenario")
@@ -80,9 +90,17 @@ func (p *AnthropicPlugin) handleMessages(w http.ResponseWriter, r *http.Request)
 	}
 
 	if scenario.ResponseType == "tool_use" {
-		p.streamToolUseResponse(w, req.Model, scenario, string(bodyBytes))
+		if req.Stream {
+			p.streamToolUseResponse(w, req.Model, scenario, string(bodyBytes))
+		} else {
+			p.respondToolUseNonStream(w, req.Model, scenario, string(bodyBytes))
+		}
 	} else {
-		p.streamTextResponse(w, req.Model, scenario.ResponseText, string(bodyBytes), scenario.ID)
+		if req.Stream {
+			p.streamTextResponse(w, req.Model, scenario.ResponseText, string(bodyBytes), scenario.ID)
+		} else {
+			p.respondTextNonStream(w, req.Model, scenario.ResponseText, string(bodyBytes), scenario.ID)
+		}
 	}
 }
 
@@ -137,6 +155,81 @@ func (p *AnthropicPlugin) streamToolUseResponse(w http.ResponseWriter, model str
 	if f, ok := w.(http.Flusher); ok {
 		f.Flush()
 	}
+}
+
+// respondTextNonStream returns a single JSON Message body with a text content
+// block. Mirrors streamTextResponse but for stream:false clients.
+func (p *AnthropicPlugin) respondTextNonStream(w http.ResponseWriter, model, text, requestBody, scenarioID string) {
+	p.store.CreateMessage(&Message{
+		RequestBody:  requestBody,
+		ResponseType: "text",
+		ScenarioID:   scenarioID,
+	})
+
+	msgID := "msg_" + strings.ReplaceAll(uuid.New().String(), "-", "")[:12]
+
+	body := map[string]interface{}{
+		"id":   msgID,
+		"type": "message",
+		"role": "assistant",
+		"content": []map[string]interface{}{
+			{"type": "text", "text": text},
+		},
+		"model":         model,
+		"stop_reason":   "end_turn",
+		"stop_sequence": nil,
+		"usage": map[string]interface{}{
+			"input_tokens":  0,
+			"output_tokens": 0,
+		},
+	}
+	writeJSON(w, body)
+}
+
+// respondToolUseNonStream returns a single JSON Message body whose content
+// array holds a tool_use block. Mirrors streamToolUseResponse but for
+// stream:false clients.
+func (p *AnthropicPlugin) respondToolUseNonStream(w http.ResponseWriter, model string, scenario *Scenario, requestBody string) {
+	p.store.CreateMessage(&Message{
+		RequestBody:  requestBody,
+		ResponseType: "tool_use",
+		ScenarioID:   scenario.ID,
+	})
+
+	msgID := "msg_" + strings.ReplaceAll(uuid.New().String(), "-", "")[:12]
+	toolUseID := "toolu_" + strings.ReplaceAll(uuid.New().String(), "-", "")[:12]
+
+	// Scenario.ToolInput is stored as a JSON string; emit it as a JSON object
+	// rather than a string so the response matches real Anthropic.
+	var toolInput interface{} = map[string]interface{}{}
+	if scenario.ToolInput != "" {
+		var parsed interface{}
+		if err := json.Unmarshal([]byte(scenario.ToolInput), &parsed); err == nil {
+			toolInput = parsed
+		}
+	}
+
+	body := map[string]interface{}{
+		"id":   msgID,
+		"type": "message",
+		"role": "assistant",
+		"content": []map[string]interface{}{
+			{
+				"type":  "tool_use",
+				"id":    toolUseID,
+				"name":  scenario.ToolName,
+				"input": toolInput,
+			},
+		},
+		"model":         model,
+		"stop_reason":   "tool_use",
+		"stop_sequence": nil,
+		"usage": map[string]interface{}{
+			"input_tokens":  0,
+			"output_tokens": 0,
+		},
+	}
+	writeJSON(w, body)
 }
 
 // containsToolResult checks if the message is a user message containing a tool_result block.

--- a/plugins/anthropic/handlers_test.go
+++ b/plugins/anthropic/handlers_test.go
@@ -393,3 +393,200 @@ func TestHandleMessagesNoScenarios(t *testing.T) {
 		t.Fatal("Missing end_turn stop reason in fallback response")
 	}
 }
+
+// assertNonStreamMessageEnvelope checks the common JSON envelope fields
+// returned by stream:false responses.
+func assertNonStreamMessageEnvelope(t *testing.T, w *httptest.ResponseRecorder, expectedModel string) map[string]interface{} {
+	t.Helper()
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	contentType := w.Header().Get("Content-Type")
+	if !strings.HasPrefix(contentType, "application/json") {
+		t.Fatalf("Expected Content-Type application/json, got %q", contentType)
+	}
+
+	var resp map[string]interface{}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("Failed to decode JSON: %v", err)
+	}
+
+	if id, _ := resp["id"].(string); !strings.HasPrefix(id, "msg_") {
+		t.Fatalf("Expected id to start with 'msg_', got %v", resp["id"])
+	}
+	if resp["type"] != "message" {
+		t.Fatalf("Expected type 'message', got %v", resp["type"])
+	}
+	if resp["role"] != "assistant" {
+		t.Fatalf("Expected role 'assistant', got %v", resp["role"])
+	}
+	if resp["model"] != expectedModel {
+		t.Fatalf("Expected model %q, got %v", expectedModel, resp["model"])
+	}
+	if _, ok := resp["usage"].(map[string]interface{}); !ok {
+		t.Fatalf("Expected usage object, got %v", resp["usage"])
+	}
+
+	return resp
+}
+
+func TestHandleMessagesNonStreamText(t *testing.T) {
+	plugin := setupTestPlugin(t)
+
+	plugin.store.CreateScenario(&Scenario{
+		Pattern:      "hello",
+		ResponseType: "text",
+		ResponseText: "Hi there!",
+		Priority:     10,
+	})
+
+	w := sendMessage(t, plugin, map[string]interface{}{
+		"model":  "claude-sonnet-4-20250514",
+		"stream": false,
+		"messages": []map[string]interface{}{
+			{"role": "user", "content": "hello world"},
+		},
+	})
+
+	resp := assertNonStreamMessageEnvelope(t, w, "claude-sonnet-4-20250514")
+
+	if resp["stop_reason"] != "end_turn" {
+		t.Fatalf("Expected stop_reason 'end_turn', got %v", resp["stop_reason"])
+	}
+
+	content, ok := resp["content"].([]interface{})
+	if !ok || len(content) != 1 {
+		t.Fatalf("Expected content array of length 1, got %v", resp["content"])
+	}
+	block := content[0].(map[string]interface{})
+	if block["type"] != "text" {
+		t.Fatalf("Expected content[0].type 'text', got %v", block["type"])
+	}
+	if block["text"] != "Hi there!" {
+		t.Fatalf("Expected scenario text, got %v", block["text"])
+	}
+}
+
+func TestHandleMessagesNonStreamDefaultsToJSON(t *testing.T) {
+	// Real Anthropic treats a missing `stream` field as false. Verify the
+	// mock matches that behavior.
+	plugin := setupTestPlugin(t)
+
+	plugin.store.CreateScenario(&Scenario{
+		Pattern:      "hello",
+		ResponseType: "text",
+		ResponseText: "Hi there!",
+		Priority:     10,
+	})
+
+	w := sendMessage(t, plugin, map[string]interface{}{
+		"model": "claude-sonnet-4-20250514",
+		"messages": []map[string]interface{}{
+			{"role": "user", "content": "hello world"},
+		},
+	})
+
+	assertNonStreamMessageEnvelope(t, w, "claude-sonnet-4-20250514")
+}
+
+func TestHandleMessagesNonStreamToolUse(t *testing.T) {
+	plugin := setupTestPlugin(t)
+
+	plugin.store.CreateScenario(&Scenario{
+		Pattern:      "weather",
+		ResponseType: "tool_use",
+		ToolName:     "get_weather",
+		ToolInput:    `{"location":"San Francisco"}`,
+		Priority:     10,
+	})
+
+	w := sendMessage(t, plugin, map[string]interface{}{
+		"model":  "claude-sonnet-4-20250514",
+		"stream": false,
+		"messages": []map[string]interface{}{
+			{"role": "user", "content": "what's the weather"},
+		},
+	})
+
+	resp := assertNonStreamMessageEnvelope(t, w, "claude-sonnet-4-20250514")
+
+	if resp["stop_reason"] != "tool_use" {
+		t.Fatalf("Expected stop_reason 'tool_use', got %v", resp["stop_reason"])
+	}
+
+	content, ok := resp["content"].([]interface{})
+	if !ok || len(content) != 1 {
+		t.Fatalf("Expected content array of length 1, got %v", resp["content"])
+	}
+	block := content[0].(map[string]interface{})
+	if block["type"] != "tool_use" {
+		t.Fatalf("Expected content[0].type 'tool_use', got %v", block["type"])
+	}
+	if id, _ := block["id"].(string); !strings.HasPrefix(id, "toolu_") {
+		t.Fatalf("Expected tool_use id to start with 'toolu_', got %v", block["id"])
+	}
+	if block["name"] != "get_weather" {
+		t.Fatalf("Expected tool name 'get_weather', got %v", block["name"])
+	}
+
+	input, ok := block["input"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("Expected input to be a JSON object, got %v (type %T)", block["input"], block["input"])
+	}
+	if input["location"] != "San Francisco" {
+		t.Fatalf("Expected input.location 'San Francisco', got %v", input["location"])
+	}
+}
+
+func TestHandleMessagesNonStreamToolResultFollowUp(t *testing.T) {
+	plugin := setupTestPlugin(t)
+
+	w := sendMessage(t, plugin, map[string]interface{}{
+		"model":  "claude-sonnet-4-20250514",
+		"stream": false,
+		"messages": []map[string]interface{}{
+			{"role": "user", "content": "what's the weather"},
+			{"role": "assistant", "content": []map[string]interface{}{
+				{"type": "tool_use", "id": "toolu_123", "name": "get_weather", "input": map[string]interface{}{"location": "SF"}},
+			}},
+			{"role": "user", "content": []map[string]interface{}{
+				{"type": "tool_result", "tool_use_id": "toolu_123", "content": "72 degrees and sunny"},
+			}},
+		},
+	})
+
+	resp := assertNonStreamMessageEnvelope(t, w, "claude-sonnet-4-20250514")
+	if resp["stop_reason"] != "end_turn" {
+		t.Fatalf("Expected stop_reason 'end_turn', got %v", resp["stop_reason"])
+	}
+
+	content := resp["content"].([]interface{})
+	block := content[0].(map[string]interface{})
+	if !strings.Contains(block["text"].(string), "72 degrees and sunny") {
+		t.Fatalf("Expected tool result text in response, got %v", block["text"])
+	}
+}
+
+func TestHandleMessagesNonStreamFallback(t *testing.T) {
+	plugin := setupTestPlugin(t)
+
+	// No scenarios seeded; non-streaming should still produce a valid Message.
+	w := sendMessage(t, plugin, map[string]interface{}{
+		"model":  "claude-sonnet-4-20250514",
+		"stream": false,
+		"messages": []map[string]interface{}{
+			{"role": "user", "content": "anything"},
+		},
+	})
+
+	resp := assertNonStreamMessageEnvelope(t, w, "claude-sonnet-4-20250514")
+	if resp["stop_reason"] != "end_turn" {
+		t.Fatalf("Expected stop_reason 'end_turn', got %v", resp["stop_reason"])
+	}
+	content := resp["content"].([]interface{})
+	if len(content) != 1 {
+		t.Fatalf("Expected one content block, got %d", len(content))
+	}
+}

--- a/test/e2e/anthropic_test.go
+++ b/test/e2e/anthropic_test.go
@@ -1,0 +1,299 @@
+// ABOUTME: E2E integration tests for the Anthropic Messages API plugin.
+// ABOUTME: Tests scenario CRUD plus streaming and non-streaming text/tool_use responses.
+
+package e2e_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestAnthropicScenarioCRUD(t *testing.T) {
+	ts := StartTestServer(t)
+	defer ts.Close()
+
+	// Step 1: Create a scenario
+	scenarioReq := map[string]interface{}{
+		"pattern":       "hello",
+		"response_type": "text",
+		"response_text": "Hi from ISH!",
+		"priority":      10,
+	}
+
+	resp := ts.POST(t, "/v1/scenarios", scenarioReq)
+	AssertStatusCode(t, resp, 201)
+
+	var created map[string]interface{}
+	DecodeJSON(t, resp, &created)
+
+	scenarioID, ok := created["id"].(string)
+	if !ok || scenarioID == "" {
+		t.Fatal("expected scenario ID in response")
+	}
+
+	// Step 2: List scenarios and verify at least 1 exists
+	resp = ts.GET(t, "/v1/scenarios")
+	AssertStatusCode(t, resp, 200)
+
+	var scenarios []map[string]interface{}
+	DecodeJSON(t, resp, &scenarios)
+
+	if len(scenarios) < 1 {
+		t.Fatalf("expected at least 1 scenario, got %d", len(scenarios))
+	}
+
+	// Step 3: Delete the scenario
+	resp = ts.DELETE(t, "/v1/scenarios/"+scenarioID)
+	AssertStatusCode(t, resp, 204)
+}
+
+func TestAnthropicStreamingTextResponse(t *testing.T) {
+	ts := StartTestServer(t)
+	defer ts.Close()
+
+	// Seed a scenario that matches "greetings"
+	scenarioReq := map[string]interface{}{
+		"pattern":       "greetings",
+		"response_type": "text",
+		"response_text": "Hello, friend!",
+		"priority":      10,
+	}
+
+	resp := ts.POST(t, "/v1/scenarios", scenarioReq)
+	AssertStatusCode(t, resp, 201)
+
+	// Send a messages request that should match the scenario
+	messagesReq := map[string]interface{}{
+		"model":  "claude-sonnet-4-20250514",
+		"stream": true,
+		"messages": []map[string]interface{}{
+			{
+				"role":    "user",
+				"content": "greetings friend",
+			},
+		},
+	}
+
+	resp = ts.POST(t, "/v1/messages", messagesReq)
+	AssertStatusCode(t, resp, 200)
+
+	// Verify Content-Type is text/event-stream
+	contentType := resp.Header.Get("Content-Type")
+	if contentType != "text/event-stream" {
+		t.Fatalf("expected Content-Type text/event-stream, got %s", contentType)
+	}
+
+	body := ReadBody(t, resp)
+
+	// Verify SSE event structure
+	if !strings.Contains(body, "event: message_start") {
+		t.Error("expected body to contain 'event: message_start'")
+	}
+	if !strings.Contains(body, "Hello, friend!") {
+		t.Error("expected body to contain response text 'Hello, friend!'")
+	}
+	if !strings.Contains(body, "event: message_stop") {
+		t.Error("expected body to contain 'event: message_stop'")
+	}
+}
+
+func TestAnthropicStreamingToolUseResponse(t *testing.T) {
+	ts := StartTestServer(t)
+	defer ts.Close()
+
+	// Seed a tool_use scenario
+	scenarioReq := map[string]interface{}{
+		"pattern":       "what time",
+		"response_type": "tool_use",
+		"tool_name":     "get_current_time",
+		"tool_input":    "{}",
+		"priority":      10,
+	}
+
+	resp := ts.POST(t, "/v1/scenarios", scenarioReq)
+	AssertStatusCode(t, resp, 201)
+
+	// Send a messages request that should match the tool_use scenario
+	messagesReq := map[string]interface{}{
+		"model":  "claude-sonnet-4-20250514",
+		"stream": true,
+		"messages": []map[string]interface{}{
+			{
+				"role":    "user",
+				"content": "what time is it?",
+			},
+		},
+	}
+
+	resp = ts.POST(t, "/v1/messages", messagesReq)
+	AssertStatusCode(t, resp, 200)
+
+	body := ReadBody(t, resp)
+
+	// Verify tool_use response structure
+	if !strings.Contains(body, `"type":"tool_use"`) {
+		t.Error("expected body to contain '\"type\":\"tool_use\"'")
+	}
+	if !strings.Contains(body, "get_current_time") {
+		t.Error("expected body to contain tool name 'get_current_time'")
+	}
+	if !strings.Contains(body, `"stop_reason":"tool_use"`) {
+		t.Error("expected body to contain '\"stop_reason\":\"tool_use\"'")
+	}
+}
+
+func TestAnthropicNonStreamingTextResponse(t *testing.T) {
+	ts := StartTestServer(t)
+	defer ts.Close()
+
+	scenarioReq := map[string]interface{}{
+		"pattern":       "greetings",
+		"response_type": "text",
+		"response_text": "Hello, friend!",
+		"priority":      10,
+	}
+
+	resp := ts.POST(t, "/v1/scenarios", scenarioReq)
+	AssertStatusCode(t, resp, 201)
+
+	messagesReq := map[string]interface{}{
+		"model":  "claude-sonnet-4-20250514",
+		"stream": false,
+		"messages": []map[string]interface{}{
+			{"role": "user", "content": "greetings friend"},
+		},
+	}
+
+	resp = ts.POST(t, "/v1/messages", messagesReq)
+	AssertStatusCode(t, resp, 200)
+
+	contentType := resp.Header.Get("Content-Type")
+	if !strings.HasPrefix(contentType, "application/json") {
+		t.Fatalf("expected Content-Type application/json, got %s", contentType)
+	}
+
+	var msg map[string]interface{}
+	DecodeJSON(t, resp, &msg)
+
+	if msg["type"] != "message" {
+		t.Errorf("expected type 'message', got %v", msg["type"])
+	}
+	if msg["role"] != "assistant" {
+		t.Errorf("expected role 'assistant', got %v", msg["role"])
+	}
+	if msg["stop_reason"] != "end_turn" {
+		t.Errorf("expected stop_reason 'end_turn', got %v", msg["stop_reason"])
+	}
+
+	content, ok := msg["content"].([]interface{})
+	if !ok || len(content) != 1 {
+		t.Fatalf("expected content array of length 1, got %v", msg["content"])
+	}
+	block := content[0].(map[string]interface{})
+	if block["type"] != "text" {
+		t.Errorf("expected content[0].type 'text', got %v", block["type"])
+	}
+	if block["text"] != "Hello, friend!" {
+		t.Errorf("expected response text 'Hello, friend!', got %v", block["text"])
+	}
+}
+
+func TestAnthropicNonStreamingToolUseResponse(t *testing.T) {
+	ts := StartTestServer(t)
+	defer ts.Close()
+
+	scenarioReq := map[string]interface{}{
+		"pattern":       "what time",
+		"response_type": "tool_use",
+		"tool_name":     "get_current_time",
+		"tool_input":    `{"timezone":"UTC"}`,
+		"priority":      10,
+	}
+
+	resp := ts.POST(t, "/v1/scenarios", scenarioReq)
+	AssertStatusCode(t, resp, 201)
+
+	messagesReq := map[string]interface{}{
+		"model":  "claude-sonnet-4-20250514",
+		"stream": false,
+		"messages": []map[string]interface{}{
+			{"role": "user", "content": "what time is it?"},
+		},
+	}
+
+	resp = ts.POST(t, "/v1/messages", messagesReq)
+	AssertStatusCode(t, resp, 200)
+
+	var msg map[string]interface{}
+	DecodeJSON(t, resp, &msg)
+
+	if msg["stop_reason"] != "tool_use" {
+		t.Errorf("expected stop_reason 'tool_use', got %v", msg["stop_reason"])
+	}
+
+	content, ok := msg["content"].([]interface{})
+	if !ok || len(content) != 1 {
+		t.Fatalf("expected content array of length 1, got %v", msg["content"])
+	}
+	block := content[0].(map[string]interface{})
+	if block["type"] != "tool_use" {
+		t.Errorf("expected content[0].type 'tool_use', got %v", block["type"])
+	}
+	if block["name"] != "get_current_time" {
+		t.Errorf("expected tool name 'get_current_time', got %v", block["name"])
+	}
+
+	input, ok := block["input"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected input to be a JSON object, got %v (type %T)", block["input"], block["input"])
+	}
+	if input["timezone"] != "UTC" {
+		t.Errorf("expected input.timezone 'UTC', got %v", input["timezone"])
+	}
+}
+
+// TestAnthropicDefaultsToNonStreaming verifies a request without a `stream`
+// field returns JSON, matching real Anthropic where stream defaults to false.
+func TestAnthropicDefaultsToNonStreaming(t *testing.T) {
+	ts := StartTestServer(t)
+	defer ts.Close()
+
+	scenarioReq := map[string]interface{}{
+		"pattern":       "hi",
+		"response_type": "text",
+		"response_text": "Hi!",
+		"priority":      10,
+	}
+	resp := ts.POST(t, "/v1/scenarios", scenarioReq)
+	AssertStatusCode(t, resp, 201)
+
+	messagesReq := map[string]interface{}{
+		"model": "claude-sonnet-4-20250514",
+		"messages": []map[string]interface{}{
+			{"role": "user", "content": "hi"},
+		},
+	}
+
+	resp = ts.POST(t, "/v1/messages", messagesReq)
+	AssertStatusCode(t, resp, 200)
+
+	contentType := resp.Header.Get("Content-Type")
+	if !strings.HasPrefix(contentType, "application/json") {
+		t.Fatalf("expected Content-Type application/json by default, got %s", contentType)
+	}
+
+	body := ReadBody(t, resp)
+
+	// Should be a complete JSON object, not an SSE stream.
+	if strings.Contains(body, "event: message_start") {
+		t.Fatal("expected JSON body, got SSE stream")
+	}
+	var msg map[string]interface{}
+	if err := json.Unmarshal([]byte(body), &msg); err != nil {
+		t.Fatalf("failed to decode JSON: %v", err)
+	}
+	if msg["type"] != "message" {
+		t.Errorf("expected type 'message', got %v", msg["type"])
+	}
+}


### PR DESCRIPTION
## Summary
- `handleMessages` always called the SSE responders regardless of `req.Stream`. Real Anthropic returns SSE only when `stream: true`; otherwise it returns a single JSON `Message` body. Non-streaming clients (including jeff-soma's `profile_analyze_ish_test.rs`, currently `#[ignore]`'d) were getting SSE back and failing to deserialize.
- Branch on `req.Stream` at all three exit points (tool_result follow-up, no-match fallback, scenario match for both text and tool_use). Add `respondTextNonStream` / `respondToolUseNonStream` sibling responders that emit the spec-shaped JSON envelope (`id`, `type`, `role`, `content`, `model`, `stop_reason`, `stop_sequence`, `usage`). Tool input is parsed so `input` is a JSON object, not a string. SSE path untouched — mux-rs's chat loop keeps working.
- Default-omitted `stream` field is treated as `false`, matching real Anthropic.

## Test plan
- [x] `go test ./plugins/anthropic/... ./test/e2e/...` passes
- [x] Live curl: `stream:false` and missing-stream both return `Content-Type: application/json` + JSON Message body
- [x] Live curl: `stream:true` still returns `text/event-stream`
- [x] New unit tests cover non-stream text, default-omitted-stream, tool_use with parsed input object, tool_result follow-up, and no-scenarios fallback
- [x] New e2e tests cover non-streaming text, non-streaming tool_use, and default-omitted-stream
- [ ] jeff-soma runs `cargo test -- --ignored` against ISH on :9000 — `profile_analyze_ish_test.rs` (4 tests) should now pass

## Notes
- Pre-existing failure on clean `main`: `internal/logging.TestMiddleware_RequestBodySizeLimit` panics with a nil-DB deref. Unrelated to this PR; should get its own ticket.
- Follow-up worth filing: validate `tool_input` is JSON at scenario-write time so a malformed scenario can't desync the streaming and non-streaming responses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Anthropic plugin now supports non-streaming JSON message responses alongside existing streaming (SSE) functionality
  * Tool-use scenarios fully supported in both streaming and non-streaming modes
  * Messages API defaults to non-streaming when stream parameter is omitted

<!-- end of auto-generated comment: release notes by coderabbit.ai -->